### PR TITLE
fix(deps): pin psycopg2-binary to 2.9.10

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ twine==6.1.0
 
 boto3==1.34.33
 SQLAlchemy==2.0.49
-psycopg2-binary==2.9.11
+psycopg2-binary==2.9.10
 asyncpg==0.29.0
 aiosqlite==0.20.0
 greenlet==3.0.3


### PR DESCRIPTION
## Summary
- `requirements-dev.txt` pinned `psycopg2-binary==2.9.11`, but that version does not exist on PyPI (latest is `2.9.10`).
- CI fails at `make install-dev` with: `ERROR: No matching distribution found for psycopg2-binary==2.9.11`.
- Bumps the pin down to the actual latest release, `2.9.10`.

Run: https://github.com/DotzInc/serpens/actions/runs/26124143211/job/76954501180

## Test plan
- [ ] CI `Tests (3.8)` / `Tests (3.x)` jobs pass `make install-dev`
- [ ] `make test` succeeds end-to-end